### PR TITLE
Try importing abstract base classes from collections.abc to support Python 2.7 to 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
+    - python: 3.9-dev
+      env: TOXENV=py39
     - python: 2.7
       env: TOXENV=pep8
     - python: 3.8

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/src/parver/_helpers.py
+++ b/src/parver/_helpers.py
@@ -1,7 +1,13 @@
 # coding: utf-8
 from __future__ import absolute_import, division, print_function
 
-from collections import Iterable, deque
+from collections import deque
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    # Python 2
+    from collections import Iterable
 
 import six
 

--- a/src/parver/_version.py
+++ b/src/parver/_version.py
@@ -5,8 +5,12 @@ import copy
 import itertools
 import operator
 import re
-from collections import Sequence
 from functools import partial
+try:
+    from collections.abc import Sequence
+except ImportError:
+    # Python 2
+    from collections import Sequence
 
 import attr
 import six

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = py27,py34,py35,py36,py37,py38,pep8,py3pep8,docs
+envlist = py27,py34,py35,py36,py37,py38,py39,pep8,py3pep8,docs
 
 [testenv]
 extras =


### PR DESCRIPTION
Alpha versions of Python 3.9 have dropped the ability to import Iterable and
Sequence directly from collections. We now try importing from collections.abc,
and only fallback to the previous behavior to support Python 2.7.

Another version of this PR that drops Python 2 compatibility is at https://github.com/RazerM/parver/pull/4