### PR TITLE
Suppress too_slow on test_parse_hypothesis

### DIFF
--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,13 +2,14 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
-from hypothesis import assume, given
+from hypothesis import assume, given, settings, HealthCheck
 
 from parver import ParseError, Version
 
 from .strategies import version_string, whitespace
 
 
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(whitespace, version_string(), whitespace)
 def test_parse_hypothesis(prefix, version, suffix):
     Version.parse(prefix + version + suffix)


### PR DESCRIPTION
The generator is apparently too slow on busy systems, so suppress
the health check to avoid a test failure.