### PR TITLE
Miscellaneous minor fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ source = ["src/parver", ".tox/*/lib/python*/site-packages/parver"]
 precision = 1
 exclude_lines = ["pragma: no cover", "pass"]
 
+[tool.pytest.ini_options]
+pythonpath = "src"
+
 [tool.isort]
 profile = "black"
 

--- a/src/parver/_version.py
+++ b/src/parver/_version.py
@@ -244,7 +244,7 @@ class Version:
 
     .. attribute:: pre_sep2
 
-        The seperator between the pre-release identifier and number.
+        The separator between the pre-release identifier and number.
 
     .. attribute:: post_sep1
 
@@ -252,7 +252,7 @@ class Version:
 
     .. attribute:: post_sep2
 
-        The seperator between the post release identifier and number.
+        The separator between the post release identifier and number.
 
     .. attribute:: dev_sep
 

--- a/src/parver/_version.py
+++ b/src/parver/_version.py
@@ -156,13 +156,13 @@ class Version:
         segment. The normal form is `None`.
 
     :param pre_sep2: Specify an alternate separator between the identifier and
-        number. The normal form is ``'.'``.
+        number. The normal form is `None`.
 
     :param post_sep1: Specify an alternate separator before the post release
         segment. The normal form is ``'.'``.
 
     :param post_sep2: Specify an alternate separator between the identifier and
-        number. The normal form is ``'.'``.
+        number. The normal form is `None`.
 
     :param dev_sep: Specify an alternate separator before the development
         release segment. The normal form is ``'.'``.

--- a/src/parver/_version.py
+++ b/src/parver/_version.py
@@ -313,13 +313,13 @@ class Version:
 
     pre_sep1: Optional[Separator] = attr.ib(default=None, validator=validate_sep)
     pre_sep2: Optional[Separator] = attr.ib(default=None, validator=validate_sep)
-    post_sep1: Optional[Separator] = attr.ib(
+    post_sep1: Union[Separator, UnsetType, None] = attr.ib(
         default=UNSET, validator=validate_sep_or_unset
     )
-    post_sep2: Optional[Separator] = attr.ib(
+    post_sep2: Union[Separator, UnsetType, None] = attr.ib(
         default=UNSET, validator=validate_sep_or_unset
     )
-    dev_sep: Optional[Separator] = attr.ib(
+    dev_sep: Union[Separator, UnsetType, None] = attr.ib(
         default=UNSET, validator=validate_sep_or_unset
     )
     post_tag: Optional[PostTag] = attr.ib(default=UNSET, validator=validate_post_tag)


### PR DESCRIPTION
- pytest - add "src" to pythonpath by default
- doc fix: the normal form for pre_sep2 and post_sep2 is None, not "."
- typo fix: seperator => separator
- minor typing fix